### PR TITLE
hotfix: address and nonce

### DIFF
--- a/pages/juicebox.tsx
+++ b/pages/juicebox.tsx
@@ -69,7 +69,7 @@ export default function JuiceboxPage() {
     const { data: reconfig, isLoading: reconfigLoading, error: reconfigError } = useReconfigureRequest({
         space: "juicebox",
         version: `V${version}`,
-        address: owner || '0x0000000000000000000000000000000000000000',
+        address: address || '0x0000000000000000000000000000000000000000',
         datetime: currentTime,
         network: 'mainnet'
     }, currentTime !== undefined && project === 1);
@@ -190,7 +190,6 @@ export default function JuiceboxPage() {
                         type="number"
                         placeholder="custom nonce"
                         defaultValue={reconfigData?.nonce}
-                        value={nonce}
                         onChange={(e) => setNonce(e.target.value)}
                         className="inline-flex rounded rounded-l-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" 
                     />


### PR DESCRIPTION
Send address to nance api, not owner. This is used in the nance-api to record in the V2 memo who submitted the transaction: https://github.com/jigglyjams/nance-ts/blob/d82f29db4415d0fe0cee8b4182b8090eeafd5183/src/api/api.ts#L95

Remove value from nonce field as it was overwriting api. @twodam does this seem ok to you?